### PR TITLE
(fix) Change from airbnb to standard eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,11 @@
 {
-  "extends": "airbnb"
+  "extends": "standard",
+  "installedESLint": true,
+  "plugins": [
+      "standard",
+      "promise"
+  ],
+  "rules": {
+    "semi": [2, "always"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   "devDependencies": {
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.1",
-    "eslint-config-airbnb": "^13.0.0",
+    "eslint-config-standard": "^6.2.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-react": "^6.8.0",
+    "eslint-plugin-standard": "^2.0.1",
     "grunt": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-eslint": "^19.0.0",


### PR DESCRIPTION
- Removes airbnb eslint rules
- Uses standard eslint rules
- Semicolon required at the end of statements