### PR TITLE
(fix) Override airbnb strict and import rules with warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,11 @@
 {
-  "extends": "standard",
-  "installedESLint": true,
-  "plugins": [
-      "standard",
-      "promise"
-  ],
+  "extends": "airbnb",
   "rules": {
-    "semi": [2, "always"]
+    "strict": ["warn", "never"],
+    "import/no-unresolved": ["warn", { commonjs: true, caseSensitive: true }],
+    "import/extensions": ["warn", "always", {
+      js: "never",
+      jsx: "never"
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,10 @@
   "devDependencies": {
     "babel-jest": "18.0.0",
     "babel-preset-react-native": "1.9.1",
-    "eslint-config-standard": "^6.2.1",
+    "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
-    "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-react": "^6.8.0",
-    "eslint-plugin-standard": "^2.0.1",
     "grunt": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-eslint": "^19.0.0",


### PR DESCRIPTION
- Use airbnb eslint rules
- Override strict and import rules with warnings instead of errors